### PR TITLE
Add makefile and gitignore for wasm client code in test

### DIFF
--- a/src/transactions/test/wasm/.gitignore
+++ b/src/transactions/test/wasm/.gitignore
@@ -1,0 +1,1 @@
+zig-cache/

--- a/src/transactions/test/wasm/Makefile
+++ b/src/transactions/test/wasm/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build
+
+build:
+	zig build-lib test_invoke_contract.zig -target wasm32-freestanding -dynamic -O ReleaseSmall


### PR DESCRIPTION
### What
Add makefile and gitignore for the Wasm client code in the test.

### Why
Don't need to keep remembering command.