### PR TITLE
Log unknown values

### DIFF
--- a/src/transactions/ContractHostTypes.cpp
+++ b/src/transactions/ContractHostTypes.cpp
@@ -119,6 +119,11 @@ operator<<(std::ostream& out, HostVal const& v)
     {
         out << "obj(" << v.asObject() << ')';
     }
+    else
+    {
+        auto payload = v.payload();
+        out << "unknown(" << payload << ",0x" << std::hex << payload << ')';
+    }
     return out;
 }
 


### PR DESCRIPTION
### What
Log values passed to `logValue` that aren't recognized as a value with a known string format to serialize to, as the raw integer.

### Why
While not knowing what I was doing I managed to cause a host value to be not a valid host value and I wasn't seeing any log line.